### PR TITLE
fix wrong usage of argparse module

### DIFF
--- a/bin/gdeploy
+++ b/bin/gdeploy
@@ -106,7 +106,10 @@ class GlusterDeploy(PlaybookGen, Global):
         '''
         usage = 'gdeploy [-h] [-v] [-vv] [-c CONFIG_FILE] ' \
             '[-k] [-t] [volumeset <hostIP>:<volumename> <key> <value>]'
-        parser = argparse.ArgumentParser(usage=usage, version='1.0')
+        parser = argparse.ArgumentParser(usage=usage)
+        parser.add_argument('--version',
+                            action='version',
+                            version='%(prog)s 1.0')
         parser.add_argument('-c', dest='config_file',
                             help="Configuration file",
                             nargs='+',


### PR DESCRIPTION
Python module argparse is used in a wrong way. See [argparse documentation](https://docs.python.org/2/library/argparse.html#module-argparse):

> Replace the OptionParser constructor version argument with a call
> to parser.add_argument('--version', action='version', version='<the version>').

Current wrong usage of argparse module leads to ugly output on rhel 6 machines, see:

```
# gdeploy -h
/usr/lib/python2.6/site-packages/argparse.py:1575: DeprecationWarning: The "version" argument to ArgumentParser is deprecated. Please use "add_argument(..., action='version', version="N", ...)" instead
  """instead""", DeprecationWarning)
usage: gdeploy [-h] [-v] [-vv] [-c CONFIG_FILE] [-k] [volumeset <hostIP>:<volumename> <key> <value>]

positional arguments:
  volumeset       Set options for the volume

optional arguments:
  -h, --help      show this help message and exit
  -v, --version   show program's version number and exit
  -c CONFIG_FILE  Configuration file
  -k              Keep the generated ansible utility files
  -vv             verbose mode
# gdeploy --version
/usr/lib/python2.6/site-packages/argparse.py:1575: DeprecationWarning: The "version" argument to ArgumentParser is deprecated. Please use "add_argument(..., action='version', version="N", ...)" instead
  """instead""", DeprecationWarning)
1.0
#
```

Proposed commit fixes that.
