### PR TITLE
Replace single quotes with double quotes.

### DIFF
--- a/gdeployfeatures/lv/lv.json
+++ b/gdeployfeatures/lv/lv.json
@@ -87,7 +87,7 @@
           {
             "name": "cache_meta_lv",
             "required": "false",
-            "default": ''
+            "default": ""
           },
           {
             "name": "cache_meta_lvsize",


### PR DESCRIPTION
Single quotes are not decoded and results in ValueError.
