### PR TITLE
Fixing extra empty repo file without .repo extension (BZ 1342713)

### DIFF
--- a/playbooks/yum-operation.yml
+++ b/playbooks/yum-operation.yml
@@ -4,12 +4,7 @@
   gather_facts: no
 
   tasks:
-  - name: Create repo file, if necessary
-    file: path=/etc/yum.repos.d/{{item.name}} state=touch
-    with_items: repolist
-    when: repolist is defined and repolist|length > 0
-
-  - name: Enabling yum repos
+  - name: Create/Enabling yum repos
     template: src=yum.repos.d
             dest=/etc/yum.repos.d/{{ item.name }}.repo
     with_items: repolist


### PR DESCRIPTION
Ansible playbook was creating the repo file via touch followed by a template task.
The file touch task was using the filename without the .repo extension and creating the extra empty file.
Chose to remove the create task as opposed to just adding the .repo extension to the extra step.
- playbooks/yum-operation.yml - removed extraneous file touch without .repo extension

See https://bugzilla.redhat.com/show_bug.cgi?id=1342713

Signed-off-by: Jonathan Holloway loadtheaccumulator@gmail.com
