### PR TITLE
Enable samba export for ctdb clusters.

### DIFF
--- a/examples/ctdb-setup.conf
+++ b/examples/ctdb-setup.conf
@@ -52,4 +52,7 @@ force=yes
 [ctdb]
 action=setup
 public_address=10.70.37.6/24 eth0,10.70.37.8/24 eth0
-
+enable_samba=yes
+# smb_username=smbuser
+# smb_password=smbpass
+# smb_mountpoint=/mnt/smb

--- a/examples/ctdb_with_virutal_ips.conf
+++ b/examples/ctdb_with_virutal_ips.conf
@@ -7,3 +7,6 @@ action=setup
 public_address=10.70.37.6/24 eth0,10.70.37.8/24 eth0
 ctdb_nodes=192.168.1.1,192.168.2.5
 volname=samba1
+#enable_samba=yes
+#samba_username=
+#samba_password=

--- a/examples/smb-setup.conf
+++ b/examples/smb-setup.conf
@@ -16,23 +16,3 @@ smb=yes
 smb_username=bilbo
 smb_password=shireeleventyone
 smb_mountpoint=/mnt/precious
-
-
-[ctdb]
-action=setup
-public_address=192.168.1.{1..3}/24 eth1;eth2
-CTDB_PUBLIC_ADDRESSES=/etc/ctdb/public_addresses
-CTDB_NODES=/etc/ctdb/nodes
-CTDB_MANAGES_SAMBA=no
-CTDB_SET_DeterministicIPs=1
-CTDB_SET_RecoveryBanPeriod=120
-CTDB_SET_KeepaliveInterval=5
-CTDB_SET_KeepaliveLimit=5
-CTDB_SET_MonitorInterval=15
-CTDB_RECOVERY_LOCK=/mnt/lock/reclock
-
-[clients]
-action=mount
-hosts=10.70.46.1{3,5}
-fstype=cifs
-client_mount_points=/mnt/gluster{1,3}

--- a/gdeployfeatures/ctdb/ctdb.json
+++ b/gdeployfeatures/ctdb/ctdb.json
@@ -22,18 +22,15 @@
             },
             {
                 "required": "false",
-                "name": "smb_password",
-                "default": "password"
+                "name": "smb_password"
             },
             {
                 "required": "false",
-                "name": "smb_username",
-                "default": "smbuser"
+                "name": "smb_username"
             },
             {
                 "required": "false",
-                "name": "smb_mountpoint",
-                "default": "/mnt/smbserver"
+                "name": "smb_mountpoint"
             }
         ]
       },

--- a/gdeployfeatures/ctdb/ctdb.json
+++ b/gdeployfeatures/ctdb/ctdb.json
@@ -14,6 +14,26 @@
             {
                 "required": "false",
                 "name": "ctdb_nodes"
+            },
+            {
+                "required": "false",
+                "name": "enable_samba",
+                "default": "no"
+            },
+            {
+                "required": "false",
+                "name": "smb_password",
+                "default": "password"
+            },
+            {
+                "required": "false",
+                "name": "smb_username",
+                "default": "smbuser"
+            },
+            {
+                "required": "false",
+                "name": "smb_mountpoint",
+                "default": "/mnt/smbserver"
             }
         ]
       },

--- a/gdeployfeatures/volume/volume.json
+++ b/gdeployfeatures/volume/volume.json
@@ -61,18 +61,15 @@
           },
           {
             "required": "false",
-            "name": "smb_password",
-            "default": "password"
+            "name": "smb_password"
           },
           {
             "required": "false",
-            "name": "smb_username",
-            "default": "smbuser"
+            "name": "smb_username"
           },
           {
             "required": "false",
-            "name": "smb_mountpoint",
-            "default": "/mnt/smbserver"
+            "name": "smb_mountpoint"
           },
           {
             "required": "false",
@@ -208,18 +205,15 @@
           },
           {
             "required": "false",
-            "name": "smb_password",
-            "default": "password"
+            "name": "smb_password"
           },
           {
             "required": "false",
-            "name": "smb_username",
-            "default": "smbuser"
+            "name": "smb_username"
           },
           {
             "required": "false",
-            "name": "smb_mountpoint",
-            "default": "/mnt/smbserver"
+            "name": "smb_mountpoint"
           },
           {
             "required": "false",

--- a/gdeploylib/defaults.py
+++ b/gdeploylib/defaults.py
@@ -84,6 +84,8 @@ DETACH_YML = 'gluster-peer-detach.yml'
 
 SMBSRV_YML = 'mount-in-samba-server.yml'
 SMBREPLACE_YML = 'replace_smb_conf_volname.yml'
+SMB_FOR_CTDB = 'samba_for_ctdb.yml'
+
 VOLUMESET_YML = 'gluster-volume-set.yml'
 REBALANCE_YML = 'gluster-volume-rebalance.yml'
 VOLUMESTART_YML = 'gluster-volume-start.yml'

--- a/playbooks/mount-in-samba-server.yml
+++ b/playbooks/mount-in-samba-server.yml
@@ -6,8 +6,8 @@
   tasks:
   - name: Create the dir to mount the volume, skips if present
     file: path={{ item }} state=directory
-
-    with_items: "{{ smb_mountpoint }}"
+    with_items: "{{ smb_mountpoint | default([]) }}"
+    when: item is defined
 
   - name: Mount the volumes
     mount: name={{ item }}
@@ -15,8 +15,9 @@
            fstype=glusterfs,
            opts=acl,
            state=mounted
-
-    with_items: "{{ smb_mountpoint }}"
+    with_items: "{{ smb_mountpoint | default([]) }}"
+    when: item is defined
 
   - name: Provide permissions using setfacl
     command: setfacl -m user:"{{ smb_username }}":rwx "{{smb_mountpoint}}"
+    when: smb_username is defined

--- a/playbooks/replace_smb_conf_volname.yml
+++ b/playbooks/replace_smb_conf_volname.yml
@@ -22,8 +22,8 @@
 
   - name: Create a new user
     user: name="{{ smb_username }}"
+    when: smb_username is defined
 
   - name: Set smb password
-    raw: (echo {{ item }}; echo {{ item }}) | smbpasswd -s -a "{{ smb_username }}"
-    with_items: "{{ smb_password }}"
-
+    raw: (echo {{ smb_password }}; echo {{ smb_password }}) | smbpasswd -s -a "{{ smb_username }}"
+    when: smb_username is defined and smb_password is defined

--- a/playbooks/samba_for_ctdb.yml
+++ b/playbooks/samba_for_ctdb.yml
@@ -1,0 +1,23 @@
+---
+- hosts: master
+  remote_user: root
+  gather_facts: no
+
+  tasks:
+
+  - name: Add confs to glusterd.vol
+    lineinfile:
+        dest=/etc/glusterfs/glusterd.vol
+        line="    option rpc-auth-allow-insecure on"
+        insertbefore='end-volume'
+
+  - name: Restart glusterd services
+    service: name=glusterd state=restarted
+
+  - name: Create a new user
+    user: name="{{ smb_username }}"
+
+  - name: Set smb password
+    raw: (echo {{ item }}; echo {{ item }}) | smbpasswd -s -a "{{ smb_username }}"
+    with_items: "{{ smb_password }}"
+

--- a/playbooks/samba_for_ctdb.yml
+++ b/playbooks/samba_for_ctdb.yml
@@ -16,8 +16,8 @@
 
   - name: Create a new user
     user: name="{{ smb_username }}"
+    when: smb_username is defined
 
   - name: Set smb password
-    raw: (echo {{ item }}; echo {{ item }}) | smbpasswd -s -a "{{ smb_username }}"
-    with_items: "{{ smb_password }}"
-
+    raw: (echo {{ smb_password }}; echo {{ smb_password }}) | smbpasswd -s -a "{{ smb_username }}"
+    when: smb_password is defined and smb_username is defined


### PR DESCRIPTION
Add support to:
1. Enable samba for an existing ctdb cluster.
2. Enable samba while creating a ctdb cluster.
