### PR TITLE
Fixed a couple of bugs

### DIFF
--- a/gdeployfeatures/clients/clients.py
+++ b/gdeployfeatures/clients/clients.py
@@ -51,9 +51,15 @@ def fuse_mount(mnt, host, section_dict):
     return section_dict
 
 def cifs_mount(mnt, host, section_dict):
-    if not section_dict['smb_username'] or not section_dict[
-            'smb_password']:
-        print "\nError: Provide smb_username and smb_password " \
+    try:
+        samba_username = section_dict['smb_username']
+        samba_password = section_dict['smb_password']
+    except KeyError, k:
+        print "%s is a required field"%k
+        samba_username = samba_password = False
+
+    if not samba_username or not samba_password:
+        print "Error: Provide smb_username and smb_password " \
                 "for CIFS mount"
         return False
     global client_mounts, helpers

--- a/gdeploylib/call_features.py
+++ b/gdeploylib/call_features.py
@@ -82,6 +82,9 @@ def get_feature_dir(section):
 
     section_dict, yml = feature_call(section_dict)
 
+    if section_dict == False or section_dict == None or section_dict == {}:
+        return
+
     for key in section_dict.keys():
         section_dict[key.replace('-', '_')] = section_dict.pop(key)
 

--- a/gdeploylib/helpers.py
+++ b/gdeploylib/helpers.py
@@ -460,8 +460,18 @@ class Helpers(Global, YamlWriter):
             Global.inventory)
         try:
             if not Global.master:
-                Global.master = [list(set(Global.current_hosts) - set(
-                    Global.brick_hosts))[0]]
+                # We set the `master' variable in group_vars/all file here.
+                # If brick_hosts are present use one of them as master.
+                # Else use one from Global.current_hosts.
+                #
+                # Previous solution: [list(set(Global.current_hosts) - set(
+                # Global.brick_hosts))[0]] fails when length of
+                # Global.current_hosts was equal to Global.brick_hosts
+                # Or less than Global.brick_hosts
+                if Global.brick_hosts:
+                    Global.master = Global.brick_hosts[0]
+                else:
+                    Global.master = Global.current_hosts[0]
         except:
             pass
         try:

--- a/playbooks/gluster-peer-probe.yml
+++ b/playbooks/gluster-peer-probe.yml
@@ -9,5 +9,5 @@
           hosts="{{ to_be_probed }}"
           master="{{master}}"
 
-  - name: Pause for some seconds
+  - name: Pause for a few seconds
     pause: seconds=5


### PR DESCRIPTION
1. While mounting samba client, if smb_username/password is not given, die
   gracefully with an error message, do not throw traceback.
2. If the number of hosts in `[hosts]' section were equal to hosts
   listed in brick_dirs variable in`[volume]' section, the `master'
   variable was not being set in group_vars/all and peer probe would
   fail. Just pick one of the hosts from brick_dirs variable if available
   else pick one from`hosts' section as master.
