### PR TITLE
Add exit-on-error feature to volume and peer sections

### DIFF
--- a/gdeployfeatures/peer/peer.json
+++ b/gdeployfeatures/peer/peer.json
@@ -4,6 +4,9 @@
       "probe": {
         "options": [
           {
+             "required": "false",
+             "name": "ignore_peer_errors",
+             "default": "yes"
           }
         ]
       },
@@ -13,6 +16,11 @@
               "name": "force",
               "required": "false",
               "default": "no"
+          },
+          {
+             "required": "false",
+             "name": "ignore_peer_errors",
+             "default": "yes"
           }
         ]
       },

--- a/gdeployfeatures/peer/peer.py
+++ b/gdeployfeatures/peer/peer.py
@@ -7,12 +7,14 @@ from gdeploylib import defaults, Global
 def peer_probe(section_dict):
     if not check_for_host_names():
         return False, False
+    Global.ignore_errors = section_dict.get('ignore_peer_errors')
     to_be_probed = Global.hosts + Global.brick_hosts
     to_be_probed = sorted(set(to_be_probed))
     section_dict['to_be_probed'] = to_be_probed
     return section_dict, defaults.PROBE_YML
 
 def peer_detach(section_dict):
+    Global.ignore_errors = section_dict.get('ignore_peer_errors')
     section_dict['hosts'] = Global.hosts
     if not check_for_host_names():
         return False, False

--- a/gdeployfeatures/volume/volume.json
+++ b/gdeployfeatures/volume/volume.json
@@ -89,6 +89,11 @@
             "required": "false",
             "name": "glusterfs:volfile_server",
             "default": "localhost"
+          },
+          {
+            "required": "false",
+            "name": "ignore_volume_errors",
+            "default": "yes"
           }
         ]
       },
@@ -97,6 +102,11 @@
           {
             "required": "true",
             "name": "volname"
+          },
+          {
+            "required": "false",
+            "name": "ignore_volume_errors",
+            "default": "yes"
           }
         ]
       },
@@ -118,6 +128,11 @@
             "required": "false",
             "name": "force",
             "default": "no"
+          },
+          {
+            "required": "false",
+            "name": "ignore_volume_errors",
+            "default": "yes"
           }
         ]
       },
@@ -156,6 +171,11 @@
             "required": "false",
             "name": "replica_count",
             "default": "0"
+          },
+          {
+            "required": "false",
+            "name": "ignore_volume_errors",
+            "default": "yes"
           }
         ]
       },
@@ -178,6 +198,11 @@
             "required": "false",
             "name": "force",
             "default": "no"
+          },
+          {
+            "required": "false",
+            "name": "ignore_volume_errors",
+            "default": "yes"
           }
         ]
       },
@@ -233,6 +258,11 @@
             "required": "false",
             "name": "glusterfs:volfile_server",
             "default": "localhost"
+          },
+          {
+            "required": "false",
+            "name": "ignore_volume_errors",
+            "default": "yes"
           }
         ]
       },
@@ -241,6 +271,11 @@
           {
             "required": "true",
             "name": "volname"
+          },
+          {
+            "required": "false",
+            "name": "ignore_volume_errors",
+            "default": "yes"
           }
         ]
       }

--- a/gdeployfeatures/volume/volume.py
+++ b/gdeployfeatures/volume/volume.py
@@ -12,6 +12,7 @@ writers = YamlWriter()
 
 def volume_create(section_dict):
     global helpers
+    Global.ignore_errors = section_dict.get('ignore_volume_errors')
     section_dict['volname'] = helpers.split_volume_and_hostname(
             section_dict['volname'])
     if not section_dict.get('brick_dirs'):
@@ -156,24 +157,28 @@ def check_brick_name_format(brick_name):
 
 def volume_delete(section_dict):
     global helpers
+    Global.ignore_errors = section_dict.get('ignore_volume_errors')
     section_dict['volname'] = helpers.split_volume_and_hostname(
             section_dict['volname'])
     return section_dict, defaults.VOLDEL_YML
 
 def volume_start(section_dict):
     global helpers
+    Global.ignore_errors = section_dict.get('ignore_volume_errors')
     section_dict['volname'] = helpers.split_volume_and_hostname(
             section_dict['volname'])
     return section_dict, defaults.VOLUMESTART_YML
 
 def volume_stop(section_dict):
     global helpers
+    Global.ignore_errors = section_dict.get('ignore_volume_errors')
     section_dict['volname'] = helpers.split_volume_and_hostname(
             section_dict['volname'])
     return section_dict, defaults.VOLSTOP_YML
 
 def volume_add_brick(section_dict):
     global helpers
+    Global.ignore_errors = section_dict.get('ignore_volume_errors')
     yamls = []
     section_dict['volname'] = helpers.split_volume_and_hostname(
             section_dict['volname'])
@@ -187,6 +192,7 @@ def volume_add_brick(section_dict):
 
 def volume_remove_brick(section_dict):
     global helpers
+    Global.ignore_errors = section_dict.get('ignore_volume_errors')
     section_dict['volname'] = helpers.split_volume_and_hostname(
             section_dict['volname'])
     section_dict['old_bricks'] = section_dict.pop('bricks')
@@ -194,6 +200,7 @@ def volume_remove_brick(section_dict):
 
 def volume_rebalance(section_dict):
     global helpers
+    Global.ignore_errors = section_dict.get('ignore_volume_errors')
     section_dict['volname'] = helpers.split_volume_and_hostname(
             section_dict['volname'])
     return section_dict, [defaults.VOLUMESTART_YML,
@@ -202,6 +209,7 @@ def volume_rebalance(section_dict):
 
 def volume_set(section_dict):
     global helpers
+    Global.ignore_errors = section_dict.get('ignore_volume_errors')
     section_dict['volname'] = helpers.split_volume_and_hostname(
             section_dict['volname'])
     keys = section_dict.get('key')
@@ -221,6 +229,7 @@ def volume_set(section_dict):
 
 def volume_smb_setup(section_dict):
     global helpers
+    Global.ignore_errors = section_dict.get('ignore_volume_errors')
     section_dict['volname'] = helpers.split_volume_and_hostname(
             section_dict['volname'])
     SMB_DEFAULTS = {


### PR DESCRIPTION
User can exit gdeploy if volume creation fails by adding the flag
ignore_vg_errors=no in the [vg] section.

And exit gdeploy if peer probe failed by setting ignore_peer_errors=no
in the [peer] section.
