### PR TITLE
Remove smb_enable option from CTDB

### DIFF
--- a/examples/ctdb-setup.conf
+++ b/examples/ctdb-setup.conf
@@ -52,7 +52,5 @@ force=yes
 [ctdb]
 action=setup
 public_address=10.70.37.6/24 eth0,10.70.37.8/24 eth0
-enable_samba=yes
 # smb_username=smbuser
 # smb_password=smbpass
-# smb_mountpoint=/mnt/smb

--- a/examples/ctdb_with_virutal_ips.conf
+++ b/examples/ctdb_with_virutal_ips.conf
@@ -7,6 +7,5 @@ action=setup
 public_address=10.70.37.6/24 eth0,10.70.37.8/24 eth0
 ctdb_nodes=192.168.1.1,192.168.2.5
 volname=samba1
-#enable_samba=yes
 #samba_username=
 #samba_password=

--- a/gdeployfeatures/ctdb/ctdb.json
+++ b/gdeployfeatures/ctdb/ctdb.json
@@ -4,7 +4,7 @@
       "setup": {
         "options": [
             {
-                "required": "false",
+                "required": "true",
                 "name": "volname"
             },
             {
@@ -17,20 +17,11 @@
             },
             {
                 "required": "false",
-                "name": "enable_samba",
-                "default": "no"
-            },
-            {
-                "required": "false",
                 "name": "smb_password"
             },
             {
                 "required": "false",
                 "name": "smb_username"
-            },
-            {
-                "required": "false",
-                "name": "smb_mountpoint"
             }
         ]
       },

--- a/gdeployfeatures/ctdb/ctdb.py
+++ b/gdeployfeatures/ctdb/ctdb.py
@@ -26,20 +26,9 @@ def ctdb_disable(section_dict):
     return section_dict, defaults.CHKCONFIG
 
 def ctdb_setup(section_dict):
-    option = ''
-    pattern = '^CTDB_.*'
-    opt_matches = [opt for opt in list(section_dict) if
-            re.search(pattern, opt)]
-    for key in opt_matches:
-        # This is a hack to side step the AttributeError. Will replace this with
-        # much cleaner default settings for Samba, in later releases.
-        if section_dict[key] and str(section_dict[key]).lower() != 'none':
-            option += key + '=' + str(section_dict[key]) + '\n'
-    section_dict['options'] = option
     section_dict['nodes'] = '\n'.join(sorted(set(Global.hosts)))
     paddress = section_dict.get('public_address')
     ctdbnodes = section_dict.get('ctdb_nodes')
-    enable_samba = section_dict.get('enable_samba')
 
     if paddress:
         if not isinstance(paddress, list):
@@ -68,26 +57,8 @@ def ctdb_setup(section_dict):
     section_dict, enable_yml = ctdb_enable(section_dict)
     section_dict, start_yml = ctdb_start(section_dict)
 
-    # There are three combinations possible:
-    # a. Setup CTDB
-    # b. Setup CTDB and enable samba
-    # c. Enable samba on a ctdb node
-
-    # Scenario a. Setup CTDB
-    if paddress and str(enable_samba).upper() != "YES":
-        yaml_list = [defaults.CTDB_SETUP, defaults.VOLSTOP_YML,
-                     defaults.VOLUMESTART_YML, enable_yml, start_yml,
-                     defaults.SMBSRV_YML]
-
-    # Setup CTDB and enable Samba
-    if paddress and str(enable_samba).upper() == "YES":
-        yaml_list = [defaults.CTDB_SETUP, defaults.VOLSTOP_YML,
-                     defaults.VOLUMESTART_YML, enable_yml, start_yml,
-                     defaults.SMB_FOR_CTDB, defaults.SMBSRV_YML]
-
-    # Enable Samba on an existing CTDB setup
-    if not paddress and str(enable_samba).upper() == "YES":
-        yaml_list = [enable_yml, start_yml, defaults.SMB_FOR_CTDB,
-                     defaults.SMBSRV_YML]
+    yaml_list = [defaults.CTDB_SETUP, defaults.VOLSTOP_YML,
+                 defaults.VOLUMESTART_YML, enable_yml, start_yml,
+                 defaults.SMB_FOR_CTDB]
 
     return section_dict, yaml_list

--- a/playbooks/create-mount-points.yml
+++ b/playbooks/create-mount-points.yml
@@ -6,6 +6,5 @@
   tasks:
   - name: Create the dir to mount the volume, skips if present
     file: path={{ item.mountpoint }} state=directory
-
     with_items: "{{ client_mounts }}"
-
+    ignore_errors: yes

--- a/playbooks/gluster-client-nfs-mount.yml
+++ b/playbooks/gluster-client-nfs-mount.yml
@@ -10,39 +10,53 @@
 
   - name: Uncomment STATD_PORT for rpc.statd to listen on
     shell: sed -i '/STATD_PORT/s/^#//' /etc/sysconfig/nfs
+    when: item.fstype == 'nfs'
+    with_items: "{{ client_mounts }}"
 
   - name: Uncomment LOCKD_TCPPORT for rpc.lockd to listen on
     shell: sed -i '/LOCKD_TCPPORT/s/^#//' /etc/sysconfig/nfs
+    when: item.fstype == 'nfs'
+    with_items: "{{ client_mounts }}"
 
   - name: Uncomment LOCKD_UDPPORT for rpc.lockd to listen on
     shell: sed -i '/LOCKD_UDPPORT/s/^#//' /etc/sysconfig/nfs
+    when: item.fstype == 'nfs'
+    with_items: "{{ client_mounts }}"
 
   - name: Uncomment MOUNTD_PORT for rpc.mountd to listen on
     shell: sed -i '/MOUNTD_PORT/s/^#//' /etc/sysconfig/nfs
+    when: item.fstype == 'nfs'
+    with_items: "{{ client_mounts }}"
 
   - name: Restart nfs service (RHEL 6 only)
     service: name=nfs state=restarted
-    when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "6"
+    when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "6" and item.fstype == 'nfs'
     ignore_errors: yes
+    with_items: "{{ client_mounts }}"
 
   - name: Restart rpc-statd service
     service: name=rpc-statd state=restarted
-    when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "7"
+    when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "7" and item.fstype == 'nfs'
     ignore_errors: yes
+    with_items: "{{ client_mounts }}"
 
   - name: Restart nfs-config service
     service: name=nfs-config state=restarted
-    when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "7"
+    when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "7" and item.fstype == 'nfs'
     ignore_errors: yes
+    with_items: "{{ client_mounts }}"
 
   - name: Restart nfs-mountd service
     service: name=nfs-mountd state=restarted
-    when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "7"
+    when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "7" and item.fstype == 'nfs'
     ignore_errors: yes
+    with_items: "{{ client_mounts }}"
 
   - name: Restart nfslock service (RHEL 6 & 7)
     service: name=nfslock state=restarted
     ignore_errors: yes
+    when: item.fstype == 'nfs'
+    with_items: "{{ client_mounts }}"
 
   - name: Mount the volumes if fstype is NFS
     mount: name={{ item.mountpoint }}

--- a/playbooks/mount-in-samba-server.yml
+++ b/playbooks/mount-in-samba-server.yml
@@ -8,6 +8,7 @@
     file: path={{ item }} state=directory
     with_items: "{{ smb_mountpoint | default([]) }}"
     when: item is defined
+    ignore_errors: yes
 
   - name: Mount the volumes
     mount: name={{ item }}
@@ -21,3 +22,10 @@
   - name: Provide permissions using setfacl
     command: setfacl -m user:"{{ smb_username }}":rwx "{{smb_mountpoint}}"
     when: smb_username is defined
+
+  - name: Unmount the volumes
+    mount: name="{{ item }}"
+           state=absent
+    with_items: "{{ smb_mountpoint | default([]) }}"
+    when: item is defined
+    ignore_errors: yes

--- a/playbooks/replace_smb_conf_volname.yml
+++ b/playbooks/replace_smb_conf_volname.yml
@@ -14,16 +14,23 @@
   - name: Restart glusterd services
     service: name=glusterd state=restarted
 
-  - name: Start SMB service
-    service: name=smb state=restarted
+# Setting volume options: 'stat-prefetch', 'server.allow-insecure',
+# 'storage.batch-fsync-delay-usec' happens in volume.py:volume_smb_setup
 
-  - name: Enable SMB service
-    service: name=smb enabled=yes
+# Leaving the below section commented for now. As per discussion with
+# developers, we _do not care_ about samba setup from gdeploy. Focus
+# is only on CTDB setup.
 
-  - name: Create a new user
-    user: name="{{ smb_username }}"
-    when: smb_username is defined
+  # - name: Start SMB service
+  #   service: name=smb state=restarted
 
-  - name: Set smb password
-    raw: (echo {{ smb_password }}; echo {{ smb_password }}) | smbpasswd -s -a "{{ smb_username }}"
-    when: smb_username is defined and smb_password is defined
+  # - name: Enable SMB service
+  #   service: name=smb enabled=yes
+
+  # - name: Create a new user
+  #   user: name="{{ smb_username }}"
+  #   when: smb_username is defined
+
+  # - name: Set smb password
+  #   raw: (echo {{ smb_password }}; echo {{ smb_password }}) | smbpasswd -s -a "{{ smb_username }}"
+  #   when: smb_username is defined and smb_password is defined


### PR DESCRIPTION
- We no longer need to enable samba within CTDB
- Remove smb_username and password setup from within CTDB
- umount the volume after SELinux labels are set
- Remove the CTDB_\* options, they are no longer set in conf
