### PR TITLE
Allow to configure systemd slice for glusterd

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,19 @@
+Implement systemd slice setup support in glusterd. See example below.
+The config should look more or less like the example configuration below.
+
+# Create a glusterfs slice.
+# WARNING: Works only on RHEL7.
+
+[service]
+action=create-slice
+# A directory named /etc/systemd/system/%service%.service.d will be created
+# where %service% is the service mentioned below. In our case here;
+# /etc/systemd/system/glusterd.service.d will be created.
+service=glusterd
+service_filename=99-cpu.conf
+service_section=Service
+service_keys=CPUAccounting,Slice
+service_values=yes,glusterfs.slice
+slice_section=Slice
+slice_keys=CPUQuota
+slice_values=400%

--- a/gdeployfeatures/service/service.json
+++ b/gdeployfeatures/service/service.json
@@ -6,6 +6,11 @@
           {
             "required": "true",
             "name": "service"
+          },
+          {
+            "required": "false",
+            "name": "slice_setup",
+            "default": "no"
           }
         ]
       },
@@ -22,6 +27,11 @@
           {
             "required": "true",
             "name": "service"
+          },
+          {
+            "required": "false",
+            "name": "slice_setup",
+            "default": "no"
           }
         ]
       },

--- a/gdeployfeatures/service/service.py
+++ b/gdeployfeatures/service/service.py
@@ -6,6 +6,9 @@ from gdeploylib import defaults
 
 def service_start(section_dict):
     section_dict['state'] = 'started'
+    slice_setup = section_dict.get('slice_setup')
+    if slice_setup.lower() == 'yes':
+        return setup_slice(section_dict)
     return section_dict, defaults.SERVICE_MGMT
 
 def service_stop(section_dict):
@@ -14,6 +17,9 @@ def service_stop(section_dict):
 
 def service_restart(section_dict):
     section_dict['state'] = 'restarted'
+    slice_setup = section_dict.get('slice_setup')
+    if slice_setup.lower() == 'yes':
+        return setup_slice(section_dict)
     return section_dict, defaults.SERVICE_MGMT
 
 def service_reload(section_dict):
@@ -27,3 +33,14 @@ def service_enable(section_dict):
 def service_disable(section_dict):
     section_dict['enabled'] = 'no'
     return section_dict, defaults.CHKCONFIG
+
+def setup_slice(section_dict):
+    service = section_dict.get('service')
+    yamls = defaults.SERVICE_MGMT
+    if service == 'glusterd':
+        yamls = [defaults.SLICE_SETUP, defaults.SERVICE_MGMT]
+    else:
+        print "Slice setup is currently limited to glusterd."
+        print "Ignoring slice setup"
+    return section_dict, yamls
+

--- a/gdeploylib/defaults.py
+++ b/gdeploylib/defaults.py
@@ -156,6 +156,7 @@ YUM_OP = 'yum-operation.yml'
 SERVICE_MGMT = 'service_management.yml'
 CHKCONFIG = 'chkconfig_service.yml'
 SHELL_YML = 'shell_cmd.yml'
+SLICE_SETUP = 'slice_setup.yml'
 
 # CTDB
 

--- a/playbooks/99-cpu.conf
+++ b/playbooks/99-cpu.conf
@@ -1,0 +1,3 @@
+[Service]
+CPUAccounting=yes
+Slice=glusterfs.slice

--- a/playbooks/glusterfs.slice
+++ b/playbooks/glusterfs.slice
@@ -1,0 +1,2 @@
+[Slice]
+CPUQuota=400%

--- a/playbooks/slice_setup.yml
+++ b/playbooks/slice_setup.yml
@@ -1,0 +1,32 @@
+---
+- hosts: gluster_servers
+  remote_user: root
+  gather_facts: yes
+  vars:
+    slice_dir: /etc/systemd/system/glusterd.service.d
+
+
+  # This is a glusterd only setup of slice. In future versions a generic slice
+  # setup would be implemented. Please see doc TODO for more details
+
+  tasks:
+  - name: Create slice directory for glusterd
+    file: path="{{ slice_dir }}" state=directory
+    when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "7"
+
+  - name: Add systemd slice details
+    template: src=99-cpu.conf
+              dest="{{ slice_dir }}"
+    when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "7"
+
+
+  - name: Add CPUQuota for glusterd slice
+    template: src=glusterfs.slice
+              dest=/etc/systemd/system/
+    when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "7"
+
+  # Use shell command to do daemon-reload. systemd module is available only
+  # in ansible 2.x. We had to be backward compatible to 1.x
+  - name: Run daemon-reload
+    shell: systemctl daemon-reload
+    when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "7"


### PR DESCRIPTION
Now glusterd.service can override for CPU control.
