### PR TITLE
make disable-gluster-hooks.sh idempotent ...

### DIFF
--- a/extras/scripts/disable-gluster-hooks.sh
+++ b/extras/scripts/disable-gluster-hooks.sh
@@ -11,5 +11,7 @@ FILES="1/set/post/S30samba-set.sh 1/start/post/S30samba-start.sh \
        1/stop/pre/S29CTDB-teardown.sh"
 
 for f in $FILES; do
-    rename -v S D $HOOKSDIR/$f
+    for g in $HOOKSDIR/$f;do
+        test ! -x $g || rename -v S D $g
+    done
 done


### PR DESCRIPTION
…by testing for the old file name prior to rename;

This solves the problem of gdeploy playbook aborting on a subsequent run because the script returns non-zero when the hooks have already been renamed on a prior run.
