### PR TITLE
Add a .travis file to run pep8 and pyflakes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+install:
+  - pip install pep8 pyflakes
+script:
+  - find . -name \*.py -exec pep8 {} +
+  - find . -name \*.py -exec pyflakes {} +


### PR DESCRIPTION
This needs some major fixes before being merged though.

```
$ find . -name \*.py -exec pep8 {} + | wc -l
870
$ find . -name \*.py -exec pyflakes {} + | wc -l
237

```