### PR TITLE
Add update_config_lines feature for nfs-ganesha.

### DIFF
--- a/gdeployfeatures/nfs_ganesha/nfs_ganesha.json
+++ b/gdeployfeatures/nfs_ganesha/nfs_ganesha.json
@@ -80,6 +80,10 @@
              "required": "false"
           },
           {
+            "name": "update-config-lines",
+            "required": "false"
+          },
+          {
               "name": "block-name",
               "required": "false",
               "default": "client"

--- a/gdeployfeatures/nfs_ganesha/nfs_ganesha.py
+++ b/gdeployfeatures/nfs_ganesha/nfs_ganesha.py
@@ -88,6 +88,10 @@ def nfs_ganesha_refresh_config(section_dict):
     if add_lines:
         section_dict['add-config-lines'] = helpers.split_string(add_lines, '|')
 
+    update_lines = list_to_string(section_dict.get('update-config-lines'))
+    if update_lines:
+        section_dict['update-config-lines'] = helpers.split_string(update_lines, '|')
+
     block_name = section_dict.get('block-name')
     section_dict['block-name'] = block_name
 

--- a/playbooks/ganesha-refresh-config.yml
+++ b/playbooks/ganesha-refresh-config.yml
@@ -23,6 +23,14 @@
     with_items: "{{ add_config_lines | default([]) }}"
     when: add_config_lines is defined
 
+  - name: Update lines to Ganesha export file
+    lineinfile:
+        dest="{{ ha_base_dir }}/{{ ganesha_export_conf }}"
+        regexp="{{ item.split('=')[0] }}"
+        line="{{ item }}"
+    with_items: "{{ update_config_lines | default([]) }}"
+    when: update_config_lines is defined
+
   # Use blockinfile when all the channles are updated with ansible 2.x
   # Using lineinfile for now.
   - name: Add a block to Ganesha export file


### PR DESCRIPTION
Added update_config_lines feature for nfs-ganesha.
Fixes BZ#1397738.
https://bugzilla.redhat.com/show_bug.cgi?id=1397738
The ganesha-refresh-config file was failing to modify the client permissions in the export file.
Added update_config_lines option to refresh-config for nfs-ganesha, that updates a field in the export file.
Tested it with update-refresh-config.conf file.
@sac please review the same. Thankyou.