### PR TITLE
Edit delete-line option to delete multiple lines.

### DIFF
--- a/gdeployfeatures/update_file/update_file.py
+++ b/gdeployfeatures/update_file/update_file.py
@@ -58,13 +58,8 @@ def update_file_add(section_dict):
 
 def update_file_delete_line(section_dict):
     global helpers
-    line = helpers.listify(section_dict['line'])
-    data = []
+    line = []
+    line = helpers.listify(section_dict['line'].split('|'))
     Global.ignore_errors = section_dict.get('ignore_update_file_errors')
-    for li in line:
-        files_list = {}
-        files_list['line'] = li
-        data.append(files_list)
-    section_dict['file_paths'] = data
-    Global.logger.info("Deleting line %s in file %s"%(data, section_dict['dest']))
+    Global.logger.info("Deleting line %s in file %s"%(line, section_dict['dest']))
     return section_dict, defaults.DELETE_LINE_FILE


### PR DESCRIPTION
'delete-line' option now allows the user to delete multiple lines.
Tested with the delete-line-update-file.conf, where pipe '|' can be used
to specify multiple lines.
Example:

```
[hosts]
10.70.33.33

[update-file]
action=delete-line
dest=/tmp/test.conf
line=test|action

```