### PR TITLE
Add delete-file option

### DIFF
--- a/gdeployfeatures/update_file/update_file.json
+++ b/gdeployfeatures/update_file/update_file.json
@@ -72,6 +72,19 @@
             "default": "yes"
           }
         ]
+      },
+      "delete-file": {
+        "options": [
+          {
+            "required": "true",
+            "name": "dest"
+          },
+          {
+            "required": "false",
+            "name": "ignore_update_file_errors",
+            "default": "yes"
+          }
+        ]
       }
     }
   }

--- a/gdeployfeatures/update_file/update_file.py
+++ b/gdeployfeatures/update_file/update_file.py
@@ -63,3 +63,11 @@ def update_file_delete_line(section_dict):
     Global.ignore_errors = section_dict.get('ignore_update_file_errors')
     Global.logger.info("Deleting line %s in file %s"%(line, section_dict['dest']))
     return section_dict, defaults.DELETE_LINE_FILE
+
+def update_file_delete_file(section_dict):
+    global helpers
+    dest = helpers.listify(section_dict['dest'].split('|'))
+    print dest
+    Global.ignore_errors = section_dict.get('ignore_update_file_errors')
+    Global.logger.info("Deleting file %s"%(section_dict['dest']))
+    return section_dict, defaults.DELETE_FILE

--- a/gdeployfeatures/update_file/update_file.py
+++ b/gdeployfeatures/update_file/update_file.py
@@ -9,7 +9,6 @@ from gdeploylib import Global
 helpers = Helpers()
 
 def update_file_copy(section_dict):
-    global helpers
     src = helpers.listify(section_dict['src'])
     dest = helpers.listify(section_dict['dest'])
     Global.ignore_errors = section_dict.get('ignore_update_file_errors')
@@ -32,7 +31,6 @@ def update_file_copy(section_dict):
     return section_dict, defaults.MOVE_FILE
 
 def update_file_edit(section_dict):
-    global helpers
     line = helpers.listify(section_dict['line'])
     replace = helpers.listify(section_dict['replace'])
     data = []
@@ -57,7 +55,6 @@ def update_file_add(section_dict):
     return section_dict, defaults.ADD_TO_FILE
 
 def update_file_delete_line(section_dict):
-    global helpers
     line = []
     line = helpers.listify(section_dict['line'].split('|'))
     Global.ignore_errors = section_dict.get('ignore_update_file_errors')
@@ -65,9 +62,7 @@ def update_file_delete_line(section_dict):
     return section_dict, defaults.DELETE_LINE_FILE
 
 def update_file_delete_file(section_dict):
-    global helpers
     dest = helpers.listify(section_dict['dest'].split('|'))
-    print dest
     Global.ignore_errors = section_dict.get('ignore_update_file_errors')
     Global.logger.info("Deleting file %s"%(section_dict['dest']))
     return section_dict, defaults.DELETE_FILE

--- a/gdeploylib/defaults.py
+++ b/gdeploylib/defaults.py
@@ -141,6 +141,7 @@ ADD_TO_FILE = 'add-remote-file.yml'
 EDIT_FILE = 'edit-remote-file.yml'
 MOVE_FILE = 'move-file-from-local-to-remote.yml'
 DELETE_LINE_FILE = 'delete-line-remote-file.yml'
+DELETE_FILE = 'delete-remote-file.yml'
 
 
 # FIREWALLD

--- a/playbooks/delete-remote-file.yml
+++ b/playbooks/delete-remote-file.yml
@@ -1,0 +1,9 @@
+---
+- hosts: gluster_servers
+  remote_user: root
+  gather_facts: no
+
+  tasks:
+  - name: Deleting the remote file
+    file: dest={{ dest }}
+          state=absent


### PR DESCRIPTION
Added a delete-file option to allow a user to delete a remote file.
tested with delete-file.conf file. Example:
```
[hosts]
10.70.37.203

[update-file]
action=delete-file
dest=/tmp/test1.conf
```
