### PR TITLE
Do not add an extra VG component while doing lvchange

### DIFF
--- a/modules/lv.py
+++ b/modules/lv.py
@@ -321,9 +321,8 @@ class LvOps(object):
     def change(self):
         poolname = self.validated_params('lvname')
         self.lv_presence_check(poolname)
-        poolname = self.get_vg_appended_name(poolname)
         zero = self.module.params['zero'] or 'n'
-        options = self.module.params['options']
+        options = self.module.params['options'] or ''
         options = ' -Z %s %s %s/%s' % (zero, options, self.vgname, poolname)
         return options
 

--- a/playbooks/auto_lvcreate_for_gluster.yml
+++ b/playbooks/auto_lvcreate_for_gluster.yml
@@ -41,4 +41,6 @@
   - name: Change the attributes of the logical volume
     lv: action=change zero=n vgname={{ item.vg }} lvname={{ item.pool }}
     with_items: "{{ lvpools }}"
-    ignore_errors: yes
+    register: res
+    failed_when: res.rc != 0 and 'zero new blocks' not in res.msg
+

--- a/playbooks/cache_setup.yml
+++ b/playbooks/cache_setup.yml
@@ -20,6 +20,8 @@
 
   - name: Setup SSD for caching | Change the attributes of the logical volume
     lv: action=change zero=n vgname="{{ vgname }}" lvname="{{ poolname }}"
+    register: res
+    failed_when: res.rc != 0 and 'zero new blocks' not in res.msg
 
   - name: Setup SSD for caching | Create cache meta logical volume
     lv: action=create lvname="{{ cache_meta_lv }}" lvtype=thick

--- a/playbooks/lvchange.yml
+++ b/playbooks/lvchange.yml
@@ -8,4 +8,5 @@
   - name: Change the attributes of the logical volume
     lv: action=change zero=n vgname="{{ vgname }}" lvname="{{ lvname }}"
         options="{{ options }}"
-
+    register: res
+    failed_when: res.rc != 0 and 'zero new blocks' not in res.msg


### PR DESCRIPTION
Set options to '' instead of None.
Check if lvchange reports `already zeroed' in the message.