### PR TITLE
Fixes #1461114: Add more sleep seconds to avoid pcsd race condition.

### DIFF
--- a/playbooks/ganesha-bootstrap-new-nodes.yml
+++ b/playbooks/ganesha-bootstrap-new-nodes.yml
@@ -113,7 +113,7 @@
     with_items: "{{ cluster_nodes }}"
 
   - name: Pause for a few seconds after pcs auth
-    pause: seconds=3
+    pause: seconds=20
 
   - name: Enable GlusterFS Share Storage service
     service: name=glusterfssharedstorage enabled=yes


### PR DESCRIPTION
Issue 1461114 was not reproducible on 4-5 nodes.
On scaling to 7 nodes, throws error about communicating to pcsd.
Adding more sleep seconds should resolve this issue.