### PR TITLE
Fixes 1489439: Allows multiple disks per volume group.

### DIFF
--- a/gdeployfeatures/vg/vg.json
+++ b/gdeployfeatures/vg/vg.json
@@ -14,11 +14,6 @@
           },
           {
             "required": "false",
-            "name": "one-to-one",
-            "default": "no"
-          },
-          {
-            "required": "false",
             "name": "ignore_vg_errors",
             "default": "yes"
           }

--- a/gdeployfeatures/vg/vg.py
+++ b/gdeployfeatures/vg/vg.py
@@ -46,9 +46,7 @@ def set_default_values(section_dict, pvnames, vgnames):
                 print "Error: %s"%msg
                 Global.logger.error(msg)
                 helpers.cleanup_and_quit()
-            if section_dict['one-to-one'] == 'no':
-                vgnames *= len(pvnames)
-            else:
+            if section_dict['one-to-one'] == 'yes':
                 vgs = []
                 for i in range(1, len(pvnames) + 1):
                     vgs.append(vgnames[0] + str(i))
@@ -57,11 +55,19 @@ def set_default_values(section_dict, pvnames, vgnames):
 
 def dictify_pv_vg_names(section_dict, pvnames, vgnames):
     data = []
-    for pv, vg in zip(pvnames, vgnames):
-        vglist = {}
-        vglist['brick'] = pv
-        vglist['vg'] = vg
+    vglist = {}
+    vglist['brick'] = ' '
+    if len(vgnames) == 1 and len(pvnames) > 1:
+        for p in pvnames:
+            vglist['brick'] += p+' '
+        vglist['vg'] = vgnames[0]
         data.append(vglist)
+    else:
+        for pv, vg in zip(pvnames, vgnames):
+            vglist = {}
+            vglist['brick'] = pv
+            vglist['vg'] = vg
+            data.append(vglist)
     section_dict['vgnames'] = data
     return section_dict
 

--- a/gdeployfeatures/vg/vg.py
+++ b/gdeployfeatures/vg/vg.py
@@ -46,11 +46,6 @@ def set_default_values(section_dict, pvnames, vgnames):
                 print "Error: %s"%msg
                 Global.logger.error(msg)
                 helpers.cleanup_and_quit()
-            if section_dict['one-to-one'] == 'yes':
-                vgs = []
-                for i in range(1, len(pvnames) + 1):
-                    vgs.append(vgnames[0] + str(i))
-                vgnames = vgs
     return dictify_pv_vg_names(section_dict, pvnames, vgnames)
 
 def dictify_pv_vg_names(section_dict, pvnames, vgnames):


### PR DESCRIPTION
Fixes bug 1489439, allowing multiple disks per volume group.
One can use the following config file:

```
[hosts]
node 1

[pv]
action=create
devices=vdb,vdc

[vg1]
action=create
vgname=RHS_vg1
pvname=vdb,vdc
```

@sac Can you please review the patch. Thanks.