### PR TITLE
Fixing vg module docstring. Option name is 'disktype'

### DIFF
--- a/modules/vg.py
+++ b/modules/vg.py
@@ -45,7 +45,7 @@ options:
         required: true for remove action
         description: Names of the Volume Groups that are to be removed
 
-    disk_type:
+    disktype:
         required: false
         choices: [raid10, raid6, jbod]
         description: Specifies which disk configuration is used while
@@ -56,12 +56,12 @@ options:
         configuration.
 
     stripe_size:
-        required: true if disk_type is provided
+        required: true if disktype is provided
         description: Specifies the stripe unit size of each disk
         in the architecture
 
     diskcount:
-        required: true if disk_type is provided
+        required: true if disktype is provided
         description: Specifies the number of data disks in the
         configuration.
 

--- a/modules/vg.py
+++ b/modules/vg.py
@@ -55,7 +55,7 @@ options:
         on the number of datadisks and the stripe unit size in the
         configuration.
 
-    stripe_size:
+    stripesize:
         required: true if disktype is provided
         description: Specifies the stripe unit size of each disk
         in the architecture


### PR DESCRIPTION
Original documentation string was mentioning option 'disk_type', but 'disktype' was used in module source code. Fixing.