### PR TITLE
mailing list url fix

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,7 @@ Quick links
 """""""""""
 
 * `Git repositories <https://github.com/gluster/gdeploy>`_
-* `Mailing list <https://www.gluster.org/mailman/listinfo/gluster-users>`_
+* `Mailing list <https://lists.gluster.org/mailman/listinfo/gluster-users>`_
 
 Contents
 """"""""


### PR DESCRIPTION
Mailing in the documentation has moved to a new URL. 