### PR TITLE
Fixes #479: Fix faulty georep setup using gdeploy

### DIFF
--- a/gdeployfeatures/geo_replication/geo_replication.py
+++ b/gdeployfeatures/geo_replication/geo_replication.py
@@ -112,10 +112,11 @@ def parse_georep_data(section_dict):
     if section_dict.has_key('mastervol'):
         section_dict['mastervolname'] = helpers.split_volume_and_hostname(
             section_dict['mastervol'])
+    section_dict['master'] = Global.master
     if section_dict.has_key('slavevol'):
         section_dict['slavevolname'] = helpers.split_volume_and_hostname(
             section_dict['slavevol'])
-    section_dict['master'] = section_dict['slave'] = Global.master
+    section_dict['slave'] = Global.master
     return section_dict
 
 


### PR DESCRIPTION
gdeploy was failing to set georep sessions due to improper
georep master nodes.
Having set the georep master nodes prior extraction of the
slave nodes helps avoid faulty georep sessions.

Signed-off-by: Devyani Kota <devyanikota@gmail.com>