### PR TITLE
XFS ENOSPC & EIO metadata settings for vdo

### DIFF
--- a/playbooks/vdo-create.yml
+++ b/playbooks/vdo-create.yml
@@ -27,3 +27,11 @@
             logicalthreads="{{ logicalthreads | default('1') }}"
             physicalthreads="{{ physicalthreads | default('1') }}"
         with_items: "{{ vdos | default([]) }}"
+
+      - name:  set xfs ENOSPC metadata settings during vdo creation
+        shell: "echo 4 | tee /sys/fs/xfs/{{ item.disk }}/error/metadata/ENOSPC/max_retries"
+        changed_when: False
+
+      - name: set xfs EIO metadata settings during vdo creation
+        shell: "echo 4 | tee /sys/fs/xfs/{{ item.disk }}/error/metadata/EIO/max_retries"
+        changed_when: False


### PR DESCRIPTION
**XFS handle conditions when VDO runs out of physical space.**

- echo 4 | tee /sys/fs/xfs/dm-13/error/metadata/ENOSPC/max_retries
- echo 4 | tee /sys/fs/xfs/dm-13/error/metadata/EIO/max_retries