### PR TITLE
default vdo writepolicy to auto

### DIFF
--- a/gdeployfeatures/vdo/vdo.py
+++ b/gdeployfeatures/vdo/vdo.py
@@ -45,7 +45,7 @@ def vdo_create(section_dict):
 def vdo_delete(section_dict):
     section_dict['state'] = 'absent'
     section_dict['vdonames'] = helpers.listify(section_dict.get('names'))
-    Global.logger.info("Deleteing vdo volume(s) %s"% section_dict['vdonames'])
+    Global.logger.info("Deleting vdo volume(s) %s"% section_dict['vdonames'])
     return section_dict, defaults.VDO_DELETE
 
 def data_not_found(item):

--- a/playbooks/vdo-create.yml
+++ b/playbooks/vdo-create.yml
@@ -18,7 +18,7 @@
             readcachesize="{{ readcachesize | default('0') }}"
             emulate512="{{ emulate512 | default('disabled') }}"
             slabsize="{{ slabsize | default('2G') }}"
-            writepolicy="{{ writepolicy | default('sync') }}"
+            writepolicy="{{ writepolicy | default('auto') }}"
             indexmem="{{ indexmem | default('0.25') }}"
             indexmode="{{ indexmode | default('dense') }}"
             ackthreads="{{ ackthreads | default('1') }}"


### PR DESCRIPTION
- In addition to the https://github.com/gluster/gdeploy/pull/495 
- The vdocreate needs to default to 'auto' as the writepolicy. 
  The default (and highly recommended) 'auto' mode checks the storage device to determine whether it
   supports flushes.   