### PR TITLE
Fixes BZ#1563923: Add variable to avoid ignoring ganesha errors

### DIFF
--- a/gdeployfeatures/nfs_ganesha/nfs_ganesha.json
+++ b/gdeployfeatures/nfs_ganesha/nfs_ganesha.json
@@ -19,6 +19,11 @@
           {
               "name": "volname",
               "required": "false"
+          },
+          {
+              "required": "false",
+              "name": "ignore_ganesha_errors",
+              "default": "yes"
           }
         ]
       },
@@ -27,6 +32,11 @@
           {
              "name": "cluster-nodes",
              "required": "true"
+          },
+          {
+             "required": "false",
+             "name": "ignore_ganesha_errors",
+             "default": "yes"
           }
         ]
       },
@@ -43,6 +53,11 @@
           {
               "name": "vip",
               "required": "true"
+          },
+          {
+              "required": "false",
+              "name": "ignore_ganesha_errors",
+              "default": "yes"
           }
         ]
       },
@@ -50,6 +65,11 @@
           "options": [
           {   "name": "nodes",
               "required": "true"
+          },
+          {
+              "required": "false",
+              "name": "ignore_ganesha_errors",
+              "default": "yes"
           }
         ]
       },
@@ -58,6 +78,11 @@
           {
               "name": "volname",
               "required": "true"
+          },
+          {
+              "required": "false",
+              "name": "ignore_ganesha_errors",
+              "default": "yes"
           }
         ]
       },
@@ -66,6 +91,11 @@
           {
               "name": "volname",
               "required": "true"
+          },
+          {
+              "required": "false",
+              "name": "ignore_ganesha_errors",
+              "default": "yes"
           }
         ]
       },
@@ -96,6 +126,11 @@
               "name": "ha-conf-dir",
               "required": "false",
               "default": "/etc/ganesha"
+          },
+          {
+              "required": "false",
+              "name": "ignore_ganesha_errors",
+              "default": "yes"
           }
         ]
       }

--- a/gdeployfeatures/nfs_ganesha/nfs_ganesha.py
+++ b/gdeployfeatures/nfs_ganesha/nfs_ganesha.py
@@ -9,6 +9,7 @@ helpers = Helpers()
 
 def nfs_ganesha_create_cluster(section_dict):
     global helpers
+    Global.ignore_errors = section_dict.get('ignore_ganesha_errors')
     Global.logger.info("Creating NFS Ganesha cluster")
     cluster_nodes = get_cluster_nodes(section_dict)
     section_dict['ha_name'] = section_dict.pop('ha-name')
@@ -37,6 +38,7 @@ def nfs_ganesha_create_cluster(section_dict):
 
 def nfs_ganesha_destroy_cluster(section_dict):
     global helpers
+    Global.ignore_errors = section_dict.get('ignore_ganesha_errors')
     Global.logger.info("Destroying NFS Ganesha cluster")
     section_dict = get_base_dir(section_dict)
     helpers.write_to_inventory('cluster_nodes',
@@ -45,6 +47,7 @@ def nfs_ganesha_destroy_cluster(section_dict):
 
 
 def nfs_ganesha_add_node(section_dict):
+    Global.ignore_errors = section_dict.get('ignore_ganesha_errors')
     Global.logger.info("Adding nodes to NFS Ganesha cluster")
     new_nodes = helpers.listify(section_dict.get('nodes'))
     cluster_nodes = section_dict.get('cluster_nodes')
@@ -69,12 +72,14 @@ def nfs_ganesha_add_node(section_dict):
 
 
 def nfs_ganesha_delete_node(section_dict):
+    Global.ignore_errors = section_dict.get('ignore_ganesha_errors')
     section_dict = get_base_dir(section_dict)
     Global.logger.info("Deleting nodes from NFS Ganesha cluster")
     return section_dict, defaults.GANESHA_DELETE_NODE
 
 
 def nfs_ganesha_export_volume(section_dict):
+    Global.ignore_errors = section_dict.get('ignore_ganesha_errors')
     section_dict['value'] = "on"
     section_dict = get_base_dir(section_dict)
     Global.logger.info("Exporting NFS Ganesha cluster volume")
@@ -83,6 +88,7 @@ def nfs_ganesha_export_volume(section_dict):
 
 
 def nfs_ganesha_unexport_volume(section_dict):
+    Global.ignore_errors = section_dict.get('ignore_ganesha_errors')
     section_dict['value'] = "off"
     section_dict = get_base_dir(section_dict)
     Global.logger.info("Unexporting NFS Ganesha cluster volume")
@@ -90,6 +96,7 @@ def nfs_ganesha_unexport_volume(section_dict):
 
 
 def nfs_ganesha_refresh_config(section_dict):
+    Global.ignore_errors = section_dict.get('ignore_ganesha_errors')
     del_lines = list_to_string(section_dict.get('del-config-lines'))
     Global.logger.info("Running refresh config on NFS Ganesha volume")
     # Split the string which is `|' delimited. Escaped `|' is handled gracefully


### PR DESCRIPTION
Currently, the implementation of nfs-ganesha with gdeploy takes
place where irrespective of whether pcs auth command fails or
not, gdeploy proceeds and executes creation of ganesha cluster.
This is not expected, and should avoid creation of ganesha cluster
incase pcs auth fails.

Signed-off-by: Devyani Kota <devyanikota@gmail.com>