### PR TITLE
Fix word splitting logic

### DIFF
--- a/gdeploy/gdeploy
+++ b/gdeploy/gdeploy
@@ -117,6 +117,7 @@ def check_ansible_installation():
 def init_global_values(args):
     global helpers
     sections_list = []
+    Global.config_file = args.config_file.name
     Global.config = helpers.read_config(args.config_file.name)
     Global.verbose = '-vv' if args.verbose else ''
     Global.keep = args.keep

--- a/gdeployfeatures/vdo/vdo.py
+++ b/gdeployfeatures/vdo/vdo.py
@@ -20,13 +20,19 @@ def vdo_create(section_dict):
     for fi in range(len(vdonames) - len(lsize)):
         lsize.append('')
 
+    # Zero-fill slabsize if not provided. VDO will default it to appropriate
+    # value.
+    for sl in range(len(vdonames) - len(slabsz)):
+        slabsz.append('')
+
     vdolist = []
     for d, n, lsize, slab in zip(disks, vdonames, lsize, slabsz):
         v = {}
         v['disk'] = d
         v['name'] = n
         v['logicalsize'] = lsize
-        v['slabsize'] = slab
+        if slab:
+            v['slabsize'] = slab
         vdolist.append(v)
     section_dict['vdos'] = vdolist
     activate = section_dict.get('activate')

--- a/gdeploylib/helpers.py
+++ b/gdeploylib/helpers.py
@@ -345,11 +345,11 @@ class Helpers(Global, YamlWriter):
         return d
 
     def get_section_pattern(self, section):
-        regexp = '(.*):(.*)'
-        sec = re.match(regexp, section)
-        if sec:
-            Global.current_hosts = self.pattern_stripping(sec.group(2))
-            section = sec.group(1)
+        sec = section.split(':', 1)
+        # If len is <= 1 we do not have section of type feature:host
+        if len(sec) > 1:
+            Global.current_hosts = self.pattern_stripping(sec[1])
+            section = sec[0]
         section = section.lower().replace('-', '_')
         section = [v for v in feature_list if re.match(v, section)]
         if not section:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-ansible>=2.4
-Jinja2>=2.9
-PyYAML==3.11
+ansible>=2.7


### PR DESCRIPTION
section:host split would work well in case of ipv4, however with
ipv6 the current logic failed since ipv6 has : as separator which
conflicted with section:host separator. For example with ipv6 the
lv would look like [lv1:fe80::6dc9:8205:9bd6:fb40] which confused
gdeploy. Now we handle this by splitting max 1 word.