### PR TITLE
Making gdeploy-3.0.0 compatible with python3-pyyaml-3.12

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -31,7 +31,7 @@
 **Setup manually as follows**
 
 1. Add ansible modules to ANSIBLE_LIBRARY environment variable
-<br/>` echo "export ANSIBLE_LIBRARY=$ANSIBLE_LIBRARY:'/path/to/gdeploy/modules/'" >> ~/.bashrc`<br/>
+<br/>` echo "export ANSIBLE_LIBRARY=$ANSIBLE_LIBRARY'/path/to/gdeploy/modules/'" >> ~/.bashrc`<br/>
 2. Add ansible playbooks(inside the templates directory) to GDEPLOY_TEMPLATES environment variable
 <br/>` echo "export GDEPLOY_TEMPLATES='path/to/gdeploy'" >> ~/.bashrc`<br/>
 3. Install glusterlib module using setuptools

--- a/gdeploy_setup.sh
+++ b/gdeploy_setup.sh
@@ -18,7 +18,7 @@ update_init_file ()
         echo "export ANSIBLE_LIBRARY=$ANSIBLE_LIBRARY" >> $INIT_FILE
     else
         # Append module path to ANSIBLE_LIBRARY
-        echo "export ANSIBLE_LIBRARY=$ANSIBLE_LIBRARY:$MODDIR" >>$INIT_FILE
+        echo "export ANSIBLE_LIBRARY=$ANSIBLE_LIBRARY$MODDIR" >>$INIT_FILE
     fi
     echo "export GDEPLOY_TEMPLATES=$DIR" >> $INIT_FILE
 }

--- a/gdeploylib/yaml_writer.py
+++ b/gdeploylib/yaml_writer.py
@@ -60,7 +60,7 @@ class YamlWriter():
         elif not hasattr(self, 'filename') or not self.filename:
             self.filename = Global.group_file
         with open(self.filename) as f:
-            list_doc = yaml.load(f, Loader=yaml.FullLoader) or {}
+            list_doc = yaml.load(f, Loader=yaml.Loader) or {}
         list_doc.update(data_dict)
         with open(self.filename, 'w') as outfile:
             if not data_flow:


### PR DESCRIPTION
The changes contain making gdeploy-3.0.0 compatible with python3-pyyaml-3.12, so that downstream build could be tested and released to accommodate on RHEL 8

Changing the doc, to fixit into proper developmental setup, the extra ":" leads to wrong pointing of ANSIBLE_LIBRARY path

