### PR TITLE
Resolves issue#544 - Unable to create multiple vgs using gdeploy-3.0.…

### DIFF
--- a/gdeploycore/backend_setup.py
+++ b/gdeploycore/backend_setup.py
@@ -141,7 +141,6 @@ class BackendSetup(Helpers):
         try:
             self.section_dict = Global.sections['backend-setup' +
                     hostname]
-            del self.section_dict['__name__']
         except KeyError:
             return
         try:


### PR DESCRIPTION
…0 #544
This change resolves the issue #544 
The change was throwing a nexception which in turn resulted in not calling the rest of the function which resulted in not properly separating items in the config file with value seperator (here (,))
 Committer: Prajith Kesava Prasad <pkesavap@redhat.com>