### PR TITLE
3.0.0

### DIFF
--- a/gdeploycore/backend_setup.py
+++ b/gdeploycore/backend_setup.py
@@ -141,7 +141,8 @@ class BackendSetup(Helpers):
         try:
             self.section_dict = Global.sections['backend-setup' +
                     hostname]
-            del self.section_dict['__name__']
+            if '__name__' in self.section_dict.keys():
+                del self.section_dict['__name__']
         except KeyError:
             return
         try:


### PR DESCRIPTION
@gobindadas @sabose 

The problem which caused  issue #544 , was because of a silent exception raised when an entity which was not there in the dictionary was removed ,that resulted in failure of invoking further methods in gdeploy leading to cause the issue #544 .

This change checks if the entity is there in the dictionary before removing it.