### PR TITLE
Changing FullLoader module to Loader module.

### DIFF
--- a/gdeploylib/helpers.py
+++ b/gdeploylib/helpers.py
@@ -65,7 +65,7 @@ class Helpers(Global, YamlWriter):
 
     def read_yaml(self, filename):
         with open(filename, 'r') as f:
-            return yaml.load(f, Loader=yaml.FullLoader)
+            return yaml.load(f, Loader=yaml.Loader)
 
     def cleanup_and_quit(self, ret=1):
         if os.path.isdir(Global.base_dir) and not Global.keep:


### PR DESCRIPTION
Since Pyyaml -3.12 has only Loader module (e.g yaml.Loader) and not FullLoader(which is availavble only at pyyaml 5.12) , this change is needed, So that it does not throw

"AttributeError: module 'yaml' has no attribute 'FullLoader'"
it resolves bugzilla:https://bugzilla.redhat.com/show_bug.cgi?id=1815987

Signed-off-by: Prajith Kesava Prasad <pkesavap@redhat.com>