### PR TITLE
Changes to accomodate pcs 0.10.x to gdeploy

### DIFF
--- a/gdeploylib/helpers.py
+++ b/gdeploylib/helpers.py
@@ -65,7 +65,7 @@ class Helpers(Global, YamlWriter):
 
     def read_yaml(self, filename):
         with open(filename, 'r') as f:
-            return yaml.load(f, Loader=yaml.FullLoader)
+            return yaml.load(f, Loader=yaml.Loader)
 
     def cleanup_and_quit(self, ret=1):
         if os.path.isdir(Global.base_dir) and not Global.keep:

--- a/playbooks/ganesha-bootstrap-new-nodes.yml
+++ b/playbooks/ganesha-bootstrap-new-nodes.yml
@@ -103,12 +103,12 @@
     ignore_errors: yes
 
   - name: Pcs cluster authenticate the hacluster on new nodes
-    shell: pcs cluster auth -u hacluster -p hacluster {{ item }}
+    shell: pcs host auth -u hacluster -p hacluster {{ item }}
     register: result
     with_items: "{{ nodes }}"
 
   - name: Pcs cluster authenticate the hacluster on existing nodes
-    shell: pcs cluster auth -u hacluster -p hacluster {{ item }}
+    shell: pcs host auth -u hacluster -p hacluster {{ item }}
     register: result
     with_items: "{{ cluster_nodes }}"
 

--- a/playbooks/ganesha-pcs-auth-new-nodes.yml
+++ b/playbooks/ganesha-pcs-auth-new-nodes.yml
@@ -5,7 +5,7 @@
 
   tasks:
   - name: Pcs cluster authenticate the hacluster on new nodes
-    shell: pcs cluster auth -u hacluster -p hacluster {{ item }}
+    shell: pcs host auth -u hacluster -p hacluster {{ item }}
     register: result
     with_items: "{{ nodes }}"
 

--- a/playbooks/pcs-authentication.yml
+++ b/playbooks/pcs-authentication.yml
@@ -5,7 +5,7 @@
 
   tasks:
   - name: Pcs cluster authenticate the hacluster users in all the nodes
-    shell: pcs cluster auth -u hacluster -p hacluster {{ item }}
+    shell: pcs host auth -u hacluster -p hacluster {{ item }}
     register: result
     with_items: "{{ cluster_nodes }}"
 


### PR DESCRIPTION
CHANGES IN PCS-0.10
              The 'pcs cluster auth' command only authenticates nodes in a local cluster and does  not
              accept  a node list. The new command for authentication is 'pcs host auth'. It allows to
              specify host names, addresses and pcsd ports.

 This PR has addressed the above mentioned change, thus making it compatible with pcs 0.10.x
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1813908