### PR TITLE
Ignoring errors while stopping kernel NFS.

### DIFF
--- a/playbooks/configure-services.yml
+++ b/playbooks/configure-services.yml
@@ -6,6 +6,7 @@
   tasks:
   - name: Stop kernel NFS
     service: name=nfs state=stopped
+    ignore_errors: yes
 
   - name: Stop network manager service
     service: name=NetworkManager state=stopped

--- a/playbooks/ganesha-bootstrap-new-nodes.yml
+++ b/playbooks/ganesha-bootstrap-new-nodes.yml
@@ -41,6 +41,7 @@
 
   - name: Stop kernel NFS
     service: name=nfs state=stopped
+    ignore_errors: yes
 
   - name: Stop network manager service
     service: name=NetworkManager state=stopped


### PR DESCRIPTION
Following the custom ignore_errors for other services which are to be stopped
 are implemented,except for NFS. Since the service is being stopped,
it would fail only if the service is not there,

resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1826804

Signed-off-by: Prajith Kesava Prasad <pkesavap@redhat.com>