### PR TITLE
Red Hat Enterprise Linux 8 uses the default networking service, NetworkManager

### DIFF
--- a/playbooks/configure-services.yml
+++ b/playbooks/configure-services.yml
@@ -16,11 +16,19 @@
     service: name=NetworkManager enabled=no
     ignore_errors: yes
 
+  - name: Start network manager service
+    service: name=NetworkManager state=started
+
+  - name: Enable network manager service
+    service: name=NetworkManager enabled=yes
+
   - name: Start network service
     service: name=network state=started
+    ignore_errors: yes
 
   - name: Enable network service
     service: name=network enabled=yes
+    ignore_errors: yes
 
   - name: Start pcsd service
     service: name=pcsd state=started

--- a/playbooks/ganesha-bootstrap-new-nodes.yml
+++ b/playbooks/ganesha-bootstrap-new-nodes.yml
@@ -51,11 +51,19 @@
     service: name=NetworkManager enabled=no
     ignore_errors: yes
 
+  - name: Start network manager service
+    service: name=NetworkManager state=started
+
+  - name: Enable network manager service
+    service: name=NetworkManager enabled=yes
+
   - name: Start network service
     service: name=network state=started
+    ignore_errors: yes
 
   - name: Enable network service
     service: name=network enabled=yes
+    ignore_errors: yes
 
   - name: Start pcsd service
     service: name=pcsd state=started


### PR DESCRIPTION
From RHEL8 NetworkManager is default networking service in RHEL 8. Unless manually configured otherwise.

This change takes care of both cases.

Signed-off-by: Prajith Kesava Prasad <pkesavap@redhat.com>