### PR TITLE
Removing the task of Disabling Network Manager on RHEL8

### DIFF
--- a/playbooks/configure-services.yml
+++ b/playbooks/configure-services.yml
@@ -8,14 +8,6 @@
     service: name=nfs state=stopped
     ignore_errors: yes
 
-  - name: Stop network manager service
-    service: name=NetworkManager state=stopped
-    ignore_errors: yes
-
-  - name: Disable network manager service
-    service: name=NetworkManager enabled=no
-    ignore_errors: yes
-
   - name: Start network manager service
     service: name=NetworkManager state=started
 

--- a/playbooks/ganesha-bootstrap-new-nodes.yml
+++ b/playbooks/ganesha-bootstrap-new-nodes.yml
@@ -43,14 +43,6 @@
     service: name=nfs state=stopped
     ignore_errors: yes
 
-  - name: Stop network manager service
-    service: name=NetworkManager state=stopped
-    ignore_errors: yes
-
-  - name: Disable network manager service
-    service: name=NetworkManager enabled=no
-    ignore_errors: yes
-
   - name: Start network manager service
     service: name=NetworkManager state=started
 


### PR DESCRIPTION
Removing the task of Disabling Network Manager  since it does not required to be disabled as per https://bugzilla.redhat.com/show_bug.cgi?id=1515171

Bug-Url:https://bugzilla.redhat.com/show_bug.cgi?id=1845042

Signed-off-by: Prajith Kesava Prasad <pkesavap@redhat.com>